### PR TITLE
remove non-owning pointers

### DIFF
--- a/src/appearancePage.cpp
+++ b/src/appearancePage.cpp
@@ -176,8 +176,7 @@ void AppearancePage::initializeScreenGroup()
     screenGroup->setLayout(screenLayout);
 }
 
-AppearancePage::AppearancePage(MainWindow *pMainWindow, QWidget *parent) : mainWindow(pMainWindow),
-                                                                           QWidget(parent)
+AppearancePage::AppearancePage(QWidget *parent) : QWidget(parent)
 {
     initializeResolutionGroup();
     initializeNamesGroup();
@@ -186,7 +185,7 @@ AppearancePage::AppearancePage(MainWindow *pMainWindow, QWidget *parent) : mainW
 
     applyButton = new QPushButton;
     applyButton->setText("Apply");
-    QObject::connect(applyButton, &QAbstractButton::clicked, this, &AppearancePage::onApply);
+    connect(applyButton, &QAbstractButton::clicked, this, &AppearancePage::onApply);
 
     mainLayout = new QVBoxLayout;
     mainLayout->addWidget(resolutionGroup);
@@ -219,7 +218,7 @@ void AppearancePage::applyResolution()
 
     Settings::Appearance::writeScaleFactor(scaleFactor);
 
-    mainWindow->rescale();
+    emit gameResolutionChanged();
 }
 
 void AppearancePage::applyPlayerNames()
@@ -240,7 +239,8 @@ void AppearancePage::applyHUD()
 
     Settings::Appearance::writeShowNameTags(showNameTags);
     Settings::Appearance::writeShowPartnerToolTip(showPartnerToolTip);
-    mainWindow->refreshNameTags(showNameTags);
+    
+    emit nameTagsChanged();
 }
 
 void AppearancePage::applyScreenDimensions()

--- a/src/appearancePage.h
+++ b/src/appearancePage.h
@@ -9,12 +9,9 @@ const float SCALE_FACTOR_INCR = 0.05F;
 // windowed app will not take up for of screen than this
 const float MAX_PROPORTION_SCREEN = 0.975F;
 
-// forward declarations
-class MainWindow;
-
 class AppearancePage : public QWidget
 {
-    MainWindow *mainWindow; // non-owning
+    Q_OBJECT
 
     std::map<int, float> indexScaleFactorMap;
 
@@ -45,17 +42,21 @@ class AppearancePage : public QWidget
     QLineEdit *screenHeightLineEdit;
 
     QPushButton *applyButton;
-    
+
     QVBoxLayout *mainLayout;
+
+signals:
+    void nameTagsChanged();
+    void gameResolutionChanged();
 
 private:
     void initializeResolutionGroup();
     void initializeNamesGroup();
     void initializeHUDGroup();
     void initializeScreenGroup();
-public:
 
-    AppearancePage(MainWindow *pMainWindow, QWidget *parent = 0);
+public:
+    AppearancePage(QWidget *parent = 0);
 
 private:
     void onApply();

--- a/src/bidDialog.cpp
+++ b/src/bidDialog.cpp
@@ -1,11 +1,9 @@
 #include "bidDialog.h"
 #include "cpu.h"
 #include "gameData.h"
-#include "messageBox.h"
 #include "utils.h"
 
-BidDialog::BidDialog(QMainWindow *pMainWindow, QWidget *parent) : mainWindow(pMainWindow),
-                                                                  ScaledQDialog(true, parent)
+BidDialog::BidDialog(QWidget *parent) : ScaledQDialog(true, parent)
 {
     ui.setupUi(this);
 
@@ -22,8 +20,8 @@ BidDialog::BidDialog(QMainWindow *pMainWindow, QWidget *parent) : mainWindow(pMa
     ui.player3Label->adjustSize();
     ui.player4Label->adjustSize();
 
-    QObject::connect(ui.bidButton, &QPushButton::pressed, this, &BidDialog::onBidButtonPressed);
-    QObject::connect(ui.passButton, &QPushButton::pressed, this, &BidDialog::onPassButtonPressed);
+    connect(ui.bidButton, &QPushButton::pressed, this, &BidDialog::onBidButtonPressed);
+    connect(ui.passButton, &QPushButton::pressed, this, &BidDialog::onPassButtonPressed);
 
     resize(BID_DIALOG_SIZE);
     setWindowIcon(QIcon(":rookicon.gif"));
@@ -73,7 +71,6 @@ void BidDialog::onBidButtonPressed()
     if (getNumPassed() == 3) // bidding round over
     {
         QDialog::accept(); // close bid dialog
-        showBidResultMsgBox();
     }
     else
     {
@@ -98,7 +95,6 @@ void BidDialog::onPassButtonPressed()
     bidPlayer.cpu->selectPartner();
 
     QDialog::reject(); // close bid dialog
-    showBidResultMsgBox();
 }
 
 void BidDialog::setupComboBox(int minBid, int maxBid, int incr)
@@ -112,18 +108,6 @@ void BidDialog::setupComboBox(int minBid, int maxBid, int incr)
     }
 
     ui.bidAmountComboBox->showNormal();
-}
-
-void BidDialog::showBidResultMsgBox()
-{
-    std::string bidResultMsg = gamedata.playerArr[gamedata.roundInfo.bidPlayer].getPlayerName() + " won the bid for " +
-                               std::to_string(gamedata.roundInfo.bidAmount) + ". " + "Bid updated.";
-
-    MessageBox msgBox;
-    msgBox.setText(QString::fromStdString(bidResultMsg));
-    msgBox.setWindowTitle("Bid Result");
-    Utils::Ui::moveParentlessDialog(&msgBox, mainWindow, DIALOG_POSITION_CENTER);
-    msgBox.exec();
 }
 
 void BidDialog::getCpuBids()

--- a/src/bidDialog.h
+++ b/src/bidDialog.h
@@ -17,14 +17,12 @@ const QSize BID_DIALOG_SIZE = {661, 302};
 
 class BidDialog : public ScaledQDialog
 {
-    QMainWindow *mainWindow; // non-owning
-
     Ui::BidDialog ui;
 
     void setupComboBox(int minBid, int maxBid, int incr);
 
 public:
-    BidDialog(QMainWindow *pMainWindow, QWidget *parent = nullptr);
+    BidDialog(QWidget *parent = nullptr);
     virtual void rescale();
     virtual void reject();
 

--- a/src/clickableCard.cpp
+++ b/src/clickableCard.cpp
@@ -67,20 +67,6 @@ void ClickableCard::mousePressEvent(QMouseEvent *event)
     parentWidgetWithClickableCardArray->onCardClicked(this);
 }
 
-void ClickableCard::enterEvent(QEvent *event)
-{
-    auto parentWidgetWithClickableCardArray = dynamic_cast<QDialogWithClickableCardArray *>(parent());
-
-    parentWidgetWithClickableCardArray->onCardHoverEnter(this);
-}
-
-void ClickableCard::leaveEvent(QEvent *event)
-{
-    auto parentWidgetWithClickableCardArray = dynamic_cast<QDialogWithClickableCardArray *>(parent());
-
-    parentWidgetWithClickableCardArray->onCardHoverLeave(this);
-}
-
 int ClickableCard::getRotation(int drawPosition) const
 {
     switch (drawPosition)

--- a/src/clickableCard.h
+++ b/src/clickableCard.h
@@ -71,8 +71,6 @@ public:
 
 protected:
     void mousePressEvent(QMouseEvent *event);
-    void enterEvent(QEvent *event);
-    void leaveEvent(QEvent *event);
 
 private:
     int getRotation(int drawPosition) const;
@@ -142,8 +140,6 @@ public:
     virtual void rescale() = 0;
 
     virtual void onCardClicked(ClickableCard *clickableCard) = 0;
-    virtual void onCardHoverEnter(ClickableCard *clickableCard) = 0;
-    virtual void onCardHoverLeave(ClickableCard *clickableCard) = 0;
 };
 
 #endif

--- a/src/gameInfoWidget.cpp
+++ b/src/gameInfoWidget.cpp
@@ -15,8 +15,7 @@ GameInfoWidgetData::GameInfoWidgetData()
     pointsMiddleKnown = false;
 }
 
-GameInfoWidget::GameInfoWidget(QMainWindow *pMainWindow, QWidget *parent) : mainWindow(pMainWindow),
-                                                                            QDialogWithClickableCardArray(false, parent)
+GameInfoWidget::GameInfoWidget(QWidget *parent) : QDialogWithClickableCardArray(false, parent)
 {
     partnerCards = new ClickableCardArray(DRAW_POSITION_GAME_INFO_WIDGET, SIZE_TINY, this);
 
@@ -132,34 +131,6 @@ void GameInfoWidget::rescale()
 }
 
 void GameInfoWidget::onCardClicked(ClickableCard *clickableCard)
-{
-    // do nothing
-}
-
-void GameInfoWidget::onCardHoverEnter(ClickableCard *clickableCard)
-{
-    if (Settings::Appearance::readShowPartnerToolTip())
-    {
-        auto playerNames = Settings::Appearance::readPlayerNames();
-
-        auto toolTipText = [&playerNames](int playerNum) -> QString {
-            switch (playerNum)
-            {
-            case PLAYER_1:
-            case PLAYER_2:
-            case PLAYER_3:
-            case PLAYER_4:
-                return QString::fromStdString(playerNames[playerNum]);
-            default:
-                return "???";
-            }
-        }(data.partnerPlayerNum);
-
-        QToolTip::showText(mainWindow->pos() + clickableCard->pos(), toolTipText, clickableCard);
-    }
-}
-
-void GameInfoWidget::onCardHoverLeave(ClickableCard *clickableCard)
 {
     // do nothing
 }

--- a/src/gameInfoWidget.h
+++ b/src/gameInfoWidget.h
@@ -52,8 +52,6 @@ struct GameInfoWidget : public QDialogWithClickableCardArray
     GameInfoWidgetData data;
 
 private:
-    QMainWindow *mainWindow; // non-owning
-
     ScaledQLabel *bidCategoryLabel;
     ScaledQLabel *bidPlayerLabel;
     ScaledQLabel *bidAmountLabel;
@@ -88,12 +86,10 @@ private:
     ScaledQLabel *player4OverallScoreLabel;
 
 public:
-    GameInfoWidget(QMainWindow *pMainWindow, QWidget *parent = nullptr);
+    GameInfoWidget(QWidget *parent = nullptr);
     virtual void rescale();
 
     virtual void onCardClicked(ClickableCard *clickableCard);
-    virtual void onCardHoverEnter(ClickableCard *clickableCard);
-    virtual void onCardHoverLeave(ClickableCard *clickableCard);
 
     void refreshWidget(GameData &pData);
 

--- a/src/gameMenuWidget.cpp
+++ b/src/gameMenuWidget.cpp
@@ -1,8 +1,6 @@
 #include "gameMenuWidget.h"
-#include "mainWindow.h"
 
-GameMenuWidget::GameMenuWidget(MainWindow *pMainWindow, QWidget *parent) : mainWindow(pMainWindow),
-                                                                           ScaledQDialog(parent)
+GameMenuWidget::GameMenuWidget(QWidget *parent) : ScaledQDialog(parent)
 {
     auto setupButton = [this](ScaledQPushButton *button, QString text, QPoint pos, QSize size) {
         button->setParent(this);
@@ -39,11 +37,11 @@ GameMenuWidget::GameMenuWidget(MainWindow *pMainWindow, QWidget *parent) : mainW
     setupButton(quitGameButton, "Quit Game", {125, 255}, {100, 25});
     quitGameButton->setToolTip("Exist the program");
 
-    QObject::connect(newGameButton, &QPushButton::pressed, this, &GameMenuWidget::onNewGameButtonPressed);
-    QObject::connect(newRoundButton, &QPushButton::pressed, this, &GameMenuWidget::onNewRoundButtonPressed);
-    QObject::connect(saveGameButton, &QPushButton::pressed, this, &GameMenuWidget::onSaveGameButtonPressed);
-    QObject::connect(loadGameButton, &QPushButton::pressed, this, &GameMenuWidget::onLoadGameButtonPressed);
-    QObject::connect(quitGameButton, &QPushButton::pressed, this, &GameMenuWidget::onQuitGameButtonPressed);
+    connect(newGameButton, &QPushButton::pressed, this, &GameMenuWidget::newGameButtonPressed);
+    connect(newRoundButton, &QPushButton::pressed, this, &GameMenuWidget::newRoundButtonPressed);
+    connect(saveGameButton, &QPushButton::pressed, this, &GameMenuWidget::saveGameButtonPressed);
+    connect(loadGameButton, &QPushButton::pressed, this, &GameMenuWidget::loadGameButtonPressed);
+    connect(quitGameButton, &QPushButton::pressed, this, &GameMenuWidget::quitGameButtonPressed);
 
     setStyleSheet("background-color: white");
     resize(GAME_MENU_WIDGET_SIZE);
@@ -60,29 +58,4 @@ void GameMenuWidget::rescale()
     for (auto button : std::vector<ScaledQPushButton *>{newGameButton, newRoundButton, saveGameButton,
                                                         loadGameButton, quitGameButton})
         button->rescale();
-}
-
-void GameMenuWidget::onNewGameButtonPressed()
-{
-    mainWindow->onNewGameAction();
-}
-
-void GameMenuWidget::onNewRoundButtonPressed()
-{
-    mainWindow->startNewRound();
-}
-
-void GameMenuWidget::onSaveGameButtonPressed()
-{
-    mainWindow->onSaveGameAction();
-}
-
-void GameMenuWidget::onLoadGameButtonPressed()
-{
-    mainWindow->onLoadGameAction();
-}
-
-void GameMenuWidget::onQuitGameButtonPressed()
-{
-    mainWindow->close();
 }

--- a/src/gameMenuWidget.h
+++ b/src/gameMenuWidget.h
@@ -4,14 +4,11 @@
 #include "common.h"
 #include "scaledWidgets.h"
 
-// forward declarations
-class MainWindow;
-
 const QSize GAME_MENU_WIDGET_SIZE = {400, 300};
 
 class GameMenuWidget : public ScaledQDialog
 {
-    MainWindow *mainWindow; // non-owning
+    Q_OBJECT
 
     ScaledQLabel *menuTitleLabel;
     ScaledQPushButton *newGameButton;
@@ -20,15 +17,16 @@ class GameMenuWidget : public ScaledQDialog
     ScaledQPushButton *loadGameButton;
     ScaledQPushButton *quitGameButton;
 
-public:
-    GameMenuWidget(MainWindow *pMainWindow, QWidget *parent = nullptr);
-    void rescale();
+signals:
+    void newGameButtonPressed();
+    void newRoundButtonPressed();
+    void saveGameButtonPressed();
+    void loadGameButtonPressed();
+    void quitGameButtonPressed();
 
-    void onNewGameButtonPressed();
-    void onNewRoundButtonPressed();
-    void onSaveGameButtonPressed();
-    void onLoadGameButtonPressed();
-    void onQuitGameButtonPressed();
+public:
+    GameMenuWidget(QWidget *parent = nullptr);
+    void rescale();
 };
 
 #endif

--- a/src/gamePage.cpp
+++ b/src/gamePage.cpp
@@ -85,7 +85,7 @@ GamePage::GamePage(QWidget *parent) : QWidget(parent)
 
     applyButton = new QPushButton;
     applyButton->setText("Apply");
-    QObject::connect(applyButton, &QAbstractButton::clicked, this, &GamePage::onApply);
+    connect(applyButton, &QAbstractButton::clicked, this, &GamePage::onApply);
 
     mainLayout = new QVBoxLayout;
     mainLayout->addWidget(bidGroup);

--- a/src/mainWidget.h
+++ b/src/mainWidget.h
@@ -5,12 +5,12 @@
 #include "common.h"
 #include "gameInfoWidget.h"
 #include "gameMenuWidget.h"
+#include "handInfo.h"
 #include "scaledWidgets.h"
 
 // forward declarations
 class CpuDecisionMaker;
 struct GameData;
-class MainWindow;
 
 // global declarations
 extern CpuDecisionMaker cpu;
@@ -75,11 +75,11 @@ struct MainWidgetData
 
 class MainWidget : public QDialogWithClickableCardArray
 {
+    Q_OBJECT
+
     MainWidgetData data;
 
 private:
-    MainWindow *mainWindow; // non-owning
-
     GameInfoWidget *infoWidget;
     GameMenuWidget *menuWidget;
 
@@ -103,13 +103,23 @@ private:
     ClickableCardArray *player4Cards;
     #endif
 
+signals:
+    void handResultMessage(PlayerCardPair &winningPair);
+    void nestResultMessage(PlayerCardPair &winningPair);
+    void invalidCardPlayed(ClickableCard *clickableCard);
+    void loadGameButtonPressed();
+    void newGameButtonPressed();
+    void newRoundButtonPressed();
+    void partnerMessage();
+    void quitGameButtonPressed();
+    void roundSummary();
+    void saveGameButtonPressed();
+
 public:
-    MainWidget(MainWindow *pMainWindow, QWidget *parent = nullptr);
+    MainWidget(QWidget *parent = nullptr);
     virtual void rescale();
 
     virtual void onCardClicked(ClickableCard *clickableCard);
-    virtual void onCardHoverEnter(ClickableCard *clickableCard);
-    virtual void onCardHoverLeave(ClickableCard *clickableCard);
 
     void refreshCardWidgets(GameData &pData);
     void refreshInfoWidget(GameData &pData);

--- a/src/mainWindow.h
+++ b/src/mainWindow.h
@@ -17,6 +17,8 @@ const QSize MAIN_WINDOW_SIZE = {1200, 850};
 
 class MainWindow : public ScaledQMainWindow
 {
+    Q_OBJECT
+
     MainWidget *widget; // central widget
 
     ScaledQProgressBar *progressBar; // display progress of time consuming actions
@@ -45,8 +47,9 @@ public:
     virtual void rescale();
 
     // preferences dialog - appearance page
-    void refreshNameTags(bool showNameTags);
+    void refreshNameTags();
 
+    // slots
     void onNewGameAction();
     void onLoadGameAction();
     void onSaveGameAction();
@@ -56,18 +59,30 @@ public:
     void onViewScoresAction();
     void onCheckUpdatesAction();
     void onAboutAction();
-
-    // main function for game
     void startNewRound();
 
     // messages
-    void showNewGameMessage();
-    void showSaveGameMessage();
-    void showLoadGameMessage();
-    void showExitMainMenuMessage();
-    void showNewRoundMessage();
-    void showGameStartingMessage();
     void showAboutMessage();
+    void showBidResultMessage();
+    void showExitMainMenuMessage();
+    void showGameStartingMessage();
+    void showInvalidCardPlayedMessage(ClickableCard *clickableCard);
+    void showInvalidMiddleDialogMessage();
+    void showLoadGameMessage();
+    void showNewGameMessage();
+    void showNewRoundMessage();
+    void showSaveGameMessage();
+    void showPartnerMessage();
+    void showHandResultMessage(PlayerCardPair &winningPair);
+    void showNestResultMessage(PlayerCardPair &winningPair);
+    void showWrongNumNestCardsMessage();
+    void showTooManyNestCardsMessage(int numMiddleCardsSelected, int numMiddleCardsAllowed);
+
+    // dialogs
+    void showNestDialog(const CardVector &originalNest);
+    void showRoundSummaryDialog();
+    void showPartnerDialog();
+    void showTrumpDialog();
 
 private:
     bool hasRoundStarted() const;

--- a/src/messageBox.cpp
+++ b/src/messageBox.cpp
@@ -12,7 +12,7 @@ MessageBox::MessageBox(QWidget *parent) : QDialogWithClickableCardArray(true, pa
     okButton->setFont(QFont("Times", 10));
     okButton->setText("OK");
 
-    QObject::connect(okButton, &QPushButton::pressed, this, &MessageBox::okButtonPressed);
+    connect(okButton, &QPushButton::pressed, this, &MessageBox::okButtonPressed);
 
     // by default, all message boxes use draw position DRAW_POSITION_MESSAGE_BOX
     // this can be overriden using method "setCardsDrawPosition"
@@ -63,7 +63,7 @@ void MessageBox::showCards(const CardVector &cardArr)
 void MessageBox::turnOnHyperLinks()
 {
     msgLabel->setTextInteractionFlags(Qt::TextBrowserInteraction);
-    QObject::connect(msgLabel, &QLabel::linkActivated, this, &MessageBox::hyperLinkClicked);
+    connect(msgLabel, &QLabel::linkActivated, this, &MessageBox::hyperLinkClicked);
 }
 
 void MessageBox::okButtonPressed()
@@ -77,16 +77,6 @@ void MessageBox::hyperLinkClicked(const QString &link)
 }
 
 void MessageBox::onCardClicked(ClickableCard *clickableCard)
-{
-    // do nothing
-}
-
-void MessageBox::onCardHoverEnter(ClickableCard *clickableCard)
-{
-    // do nothing
-}
-
-void MessageBox::onCardHoverLeave(ClickableCard *clickableCard)
 {
     // do nothing
 }

--- a/src/messageBox.h
+++ b/src/messageBox.h
@@ -29,8 +29,6 @@ protected:
     void hyperLinkClicked(const QString &link);
 
     void onCardClicked(ClickableCard *clickableCard);
-    void onCardHoverEnter(ClickableCard *clickableCard);
-    void onCardHoverLeave(ClickableCard *clickableCard);
 };
 
 #endif

--- a/src/middleDialog.h
+++ b/src/middleDialog.h
@@ -18,34 +18,38 @@ const QSize MIDDLE_DIALOG_SIZE = {724, 435};
 // output: gamedata.nest, gamedata.roundInfo.trump, gamedata.roundInfo.partnerCard
 class MiddleDialog : public QDialogWithClickableCardArray
 {
+    Q_OBJECT
+
     CardVector originalNest;
 
 private:
-    MainWidget *mainWidget; // non-owning
-    QMainWindow *mainWindow; // non-owning
-
     Ui::MiddleDialog ui;
     
     ClickableCardArray *nestCards;
     ClickableCardArray *partnerCards;
 
+signals:
+    void showInvalidMiddleDialogMessage();
+    void showNestDialog(const CardVector &originalNest);
+    void showPartnerDialog();
+    void showTrumpDialog();
+    void refreshCardWidgets(GameData &pData);
+
 public:
-    MiddleDialog(MainWidget *pMainWidget, QMainWindow *pMainWindow, QWidget *parent = nullptr);
+    MiddleDialog(QWidget *parent = nullptr);
     virtual void rescale();
     virtual void reject();
 
     virtual void onCardClicked(ClickableCard *clickableCard);
-    virtual void onCardHoverEnter(ClickableCard *clickableCard);
-    virtual void onCardHoverLeave(ClickableCard *clickableCard);
 
 private:
-    void selectNestButtonPressed();
-    void autoSelectNestButtonPressed();
-    void selectTrumpButtonPressed();
-    void autoSelectTrumpButtonPressed();
-    void selectPartnerButtonPressed();
-    void autoSelectPartnerButtonPressed();
-    void okButtonPressed();
+    void onSelectNestButtonPressed();
+    void onAutoSelectNestButtonPressed();
+    void onSelectTrumpButtonPressed();
+    void onAutoSelectTrumpButtonPressed();
+    void onSelectPartnerButtonPressed();
+    void onAutoSelectPartnerButtonPressed();
+    void onOkButtonPressed();
 
     void setupTrumpLabel(int suit);
 };

--- a/src/nestDialog.cpp
+++ b/src/nestDialog.cpp
@@ -4,9 +4,7 @@
 #include "settings.h"
 #include "utils.h"
 
-NestDialog::NestDialog(CardVector pOriginalNest, QMainWindow *pMainWindow, QWidget *parent) : originalNest(pOriginalNest),
-                                                                                              mainWindow(pMainWindow),
-                                                                                              QDialogWithClickableCardArray(true, parent)
+NestDialog::NestDialog(CardVector pOriginalNest, QWidget *parent) : originalNest(pOriginalNest), QDialogWithClickableCardArray(true, parent)
 {
     setOriginalNestStyles("background-color: white; border: 2px solid");
 
@@ -46,9 +44,9 @@ NestDialog::NestDialog(CardVector pOriginalNest, QMainWindow *pMainWindow, QWidg
     doneNestButton = new ScaledQPushButton;
     setupPushButton(doneNestButton, "Done nest...", {125, 25}, {480, 450});
 
-    QObject::connect(autoChooseNestButton, &QPushButton::pressed, this, &NestDialog::autoChooseNestButtonPressed);
-    QObject::connect(resetNestButton, &QPushButton::pressed, this, &NestDialog::resetNestButtonPressed);
-    QObject::connect(doneNestButton, &QPushButton::pressed, this, &NestDialog::doneNestButtonPressed);
+    connect(autoChooseNestButton, &QPushButton::pressed, this, &NestDialog::autoChooseNestButtonPressed);
+    connect(resetNestButton, &QPushButton::pressed, this, &NestDialog::resetNestButtonPressed);
+    connect(doneNestButton, &QPushButton::pressed, this, &NestDialog::doneNestButtonPressed);
 
     highlightCardsCheckBox = new ScaledQCheckBox;
     highlightCardsCheckBox->setParent(this);
@@ -56,7 +54,7 @@ NestDialog::NestDialog(CardVector pOriginalNest, QMainWindow *pMainWindow, QWidg
     highlightCardsCheckBox->move({700, 450});
     highlightCardsCheckBox->setFont(QFont("Times", 10));
 
-    QObject::connect(highlightCardsCheckBox, &QCheckBox::pressed,
+    connect(highlightCardsCheckBox, &QCheckBox::pressed,
                      this, &NestDialog::highlightCardsCheckBoxPressed);
 
     resize(NEST_DIALOG_SIZE);
@@ -124,16 +122,6 @@ void NestDialog::onCardClicked(ClickableCard *clickableCard)
     player1CardsPreview->showCards(gamedata.playerArr[PLAYER_1].cardArr, &originalNestStyles);
 }
 
-void NestDialog::onCardHoverEnter(ClickableCard *clickableCard)
-{
-    // do nothing
-}
-
-void NestDialog::onCardHoverLeave(ClickableCard *clickableCard)
-{
-    // do nothing
-}
-
 void NestDialog::autoChooseNestButtonPressed()
 {
     gamedata.playerArr[PLAYER_1].cpu->selectNest();
@@ -159,11 +147,7 @@ void NestDialog::doneNestButtonPressed()
 {
     if (gamedata.nest.size() != 5)
     {
-        MessageBox msgBox;
-        msgBox.setText("Nest must have exactly 5 cards");
-        msgBox.setWindowTitle("Nest problem");
-        Utils::Ui::moveParentlessDialog(&msgBox, mainWindow, DIALOG_POSITION_CENTER);
-        msgBox.exec();
+        emit showWrongNumNestCardsMessage();
     }
     else // 5 cards left in nest
     {
@@ -175,14 +159,7 @@ void NestDialog::doneNestButtonPressed()
 
         if (numMiddleCardsSelected > numMiddleCardsAllowed) // too many nest cards selected
         {
-            std::string msg = std::to_string(numMiddleCardsSelected) + " are selected but only " + std::to_string(numMiddleCardsAllowed) +
-                         " are allowed to be selected.\n\nReview selected cards.\n\nTip: Use \"Highlight nest cards\" to see selected cards.";
-
-            MessageBox msgBox;
-            msgBox.setText(QString::fromStdString(msg));
-            msgBox.setWindowTitle("Nest problem");
-            Utils::Ui::moveParentlessDialog(&msgBox, mainWindow, DIALOG_POSITION_CENTER);
-            msgBox.exec();
+            emit showTooManyNestCardsMessage(numMiddleCardsAllowed, numMiddleCardsSelected);
         }
         else
         {

--- a/src/nestDialog.h
+++ b/src/nestDialog.h
@@ -17,14 +17,14 @@ const QSize NEST_DIALOG_SIZE = {911, 506};
 // for selecting cards from nest
 class NestDialog : public QDialogWithClickableCardArray
 {
+    Q_OBJECT
+
     // output of dialog is gamedata (modify directly)
 
     CardVector originalNest;
     CardStyleMap originalNestStyles;
 
 private:
-    QMainWindow *mainWindow; // non-owning
-
     ScaledQPushButton *autoChooseNestButton;
     ScaledQPushButton *resetNestButton;
     ScaledQPushButton *doneNestButton;
@@ -37,16 +37,18 @@ private:
 
     ScaledQCheckBox *highlightCardsCheckBox;
 
+signals:
+    void showWrongNumNestCardsMessage();
+    void showTooManyNestCardsMessage(int numMiddleCardsSelected, int numMiddleCardsAllowed);
+
 public:
-    NestDialog(CardVector pOriginalNest, QMainWindow *pMainWindow, QWidget *parent = nullptr);
+    NestDialog(CardVector pOriginalNest, QWidget *parent = nullptr);
     virtual void rescale();
     virtual void reject();
 
     void setOriginalNestStyles(std::string style);
 
     virtual void onCardClicked(ClickableCard *clickableCard);
-    virtual void onCardHoverEnter(ClickableCard *clickableCard);
-    virtual void onCardHoverLeave(ClickableCard *clickableCard);
 
     void autoChooseNestButtonPressed();
     void resetNestButtonPressed();

--- a/src/partnerDialog.cpp
+++ b/src/partnerDialog.cpp
@@ -52,7 +52,7 @@ PartnerDialog::PartnerDialog(Card &pCardSelected, QWidget *parent) : cardSelecte
     cancelButton->resize(50, 25);
     cancelButton->move({700, 250});
 
-    QObject::connect(cancelButton, &QPushButton::pressed, this, &QDialog::accept);
+    connect(cancelButton, &QPushButton::pressed, this, &QDialog::accept);
 
     setWindowTitle("Click partner card...");
     setWindowIcon(QIcon(":rookicon.gif"));
@@ -81,28 +81,15 @@ void PartnerDialog::reject()
 
 void PartnerDialog::onPartnerLabelClicked(PartnerDialogLabel *label)
 {
-    std::string text = label->text().toStdString();
+    using SuitMap = std::map<std::string, CardVector *>;
 
-    if (text == "Black")
-    {
-        partnerOptionsCards->showCards(blackCards);
-    }
-    else if (text == "Green")
-    {
-        partnerOptionsCards->showCards(greenCards);
-    }
-    else if (text == "Red")
-    {
-        partnerOptionsCards->showCards(redCards);
-    }
-    else if (text == "Yellow")
-    {
-        partnerOptionsCards->showCards(yellowCards);
-    }
-    else if (text == "Wild")
-    {
-        partnerOptionsCards->showCards(wildCards);
-    }
+    SuitMap suitMap = {{"Black", &blackCards},
+                       {"Green", &greenCards},
+                       {"Red", &redCards},
+                       {"Yellow", &yellowCards},
+                       {"Wild", &wildCards}};
+
+    partnerOptionsCards->showCards(*suitMap[label->text().toStdString()]);
 }
 
 void PartnerDialog::onCardClicked(ClickableCard *clickableCard)
@@ -111,16 +98,6 @@ void PartnerDialog::onCardClicked(ClickableCard *clickableCard)
     cardSelected.value = clickableCard->data.value;
 
     QDialog::accept();
-}
-
-void PartnerDialog::onCardHoverEnter(ClickableCard *clickableCard)
-{
-    // do nothing
-}
-
-void PartnerDialog::onCardHoverLeave(ClickableCard *clickableCard)
-{
-    // do nothing
 }
 
 void PartnerDialog::setupCardArrays()
@@ -132,7 +109,7 @@ void PartnerDialog::setupCardArrays()
         aggregateCardArr.append(gamedata.nest);
     }
 
-    if(Settings::Game::readPickSelfAsPartner ())
+    if (Settings::Game::readPickSelfAsPartner())
     {
         aggregateCardArr.append(gamedata.playerArr[PLAYER_1].cardArr);
     }

--- a/src/partnerDialog.h
+++ b/src/partnerDialog.h
@@ -55,8 +55,6 @@ public:
     void onPartnerLabelClicked(PartnerDialogLabel *label);
 
     virtual void onCardClicked(ClickableCard *clickableCard);
-    virtual void onCardHoverEnter(ClickableCard *clickableCard);
-    virtual void onCardHoverLeave(ClickableCard *clickableCard);
 
     void setupCardArrays();
 };

--- a/src/preferencesDialog.cpp
+++ b/src/preferencesDialog.cpp
@@ -1,4 +1,3 @@
-#include "mainWindow.h"
 #include "preferencesDialog.h"
 
 void PreferencesDialog::setupContentsWidget()
@@ -22,12 +21,15 @@ void PreferencesDialog::setupContentsWidget()
     setupListWidgetItem(appearanceButton, "Appearance", QIcon(":appearanceButton.png"));
     setupListWidgetItem(gameButton, "Game", QIcon(":gameButton.png"));
 
-    QObject::connect(contentsWidget, &QListWidget::currentItemChanged, this, &PreferencesDialog::changePage);
+    connect(contentsWidget, &QListWidget::currentItemChanged, this, &PreferencesDialog::changePage);
 }
 
 void PreferencesDialog::setupPagesWidget()
 {
-    appearancePage = new AppearancePage(mainWindow);
+    appearancePage = new AppearancePage;
+    connect(appearancePage, &AppearancePage::nameTagsChanged, this, &PreferencesDialog::nameTagsChanged);
+    connect(appearancePage, &AppearancePage::gameResolutionChanged, this, &PreferencesDialog::gameResolutionChanged);
+
     gamePage = new GamePage;
 
     pagesWidget = new QStackedWidget;
@@ -35,8 +37,7 @@ void PreferencesDialog::setupPagesWidget()
     pagesWidget->addWidget(gamePage);
 }
 
-PreferencesDialog::PreferencesDialog(MainWindow *pMainWindow, QWidget *parent) : mainWindow(pMainWindow),
-                                                                                 QDialog(parent)
+PreferencesDialog::PreferencesDialog(QWidget *parent) : QDialog(parent)
 {
     setupContentsWidget();
     setupPagesWidget();
@@ -44,7 +45,7 @@ PreferencesDialog::PreferencesDialog(MainWindow *pMainWindow, QWidget *parent) :
     closeButton = new QPushButton;
     closeButton->setText("Close");
 
-    QObject::connect(closeButton, &QAbstractButton::clicked, this, &PreferencesDialog::onCloseButton);
+    connect(closeButton, &QAbstractButton::clicked, this, &PreferencesDialog::onCloseButton);
 
     horizontalLayout = new QHBoxLayout;
     horizontalLayout->addWidget(contentsWidget);

--- a/src/preferencesDialog.h
+++ b/src/preferencesDialog.h
@@ -7,7 +7,7 @@
 
 class PreferencesDialog : public QDialog
 {
-    MainWindow *mainWindow; // non-owning
+    Q_OBJECT
 
     QHBoxLayout *horizontalLayout;
 
@@ -27,8 +27,12 @@ class PreferencesDialog : public QDialog
     void setupContentsWidget();
     void setupPagesWidget();
 
+signals:
+    void nameTagsChanged(); // appearance page
+    void gameResolutionChanged(); // appearance page
+
 public:
-    PreferencesDialog(MainWindow *pMainWindow, QWidget *parent = nullptr);
+    PreferencesDialog(QWidget *parent = nullptr);
 
     void changePage(QListWidgetItem *current, QListWidgetItem *previous);
 

--- a/src/roundSummaryDialog.cpp
+++ b/src/roundSummaryDialog.cpp
@@ -50,7 +50,7 @@ RoundSummaryDialog::RoundSummaryDialog(QWidget *parent) : ScaledQDialog(true, pa
     okButton->resize(50, 25);
     okButton->move({400, 200});
 
-    QObject::connect(okButton, &QPushButton::pressed, this, &RoundSummaryDialog::accept);
+    connect(okButton, &QPushButton::pressed, this, &RoundSummaryDialog::accept);
 
     resize(ROUND_SUMMARY_DIALOG_SIZE);
     setWindowTitle("Round summary");

--- a/src/saveSlotDialog.cpp
+++ b/src/saveSlotDialog.cpp
@@ -23,7 +23,7 @@ SaveSlotDialog::SaveSlotDialog(int &pSlotSelected, QWidget *parent) : slotSelect
     setupListWidgetItem(saveSlot2Button, "File 2", QIcon(":saveSlot.png"));
     setupListWidgetItem(saveSlot3Button, "File 3", QIcon(":saveSlot.png"));
 
-    QObject::connect(contentsWidget, &QListWidget::currentItemChanged, this, &SaveSlotDialog::changePage);
+    connect(contentsWidget, &QListWidget::currentItemChanged, this, &SaveSlotDialog::changePage);
 
     saveSlot1Page = new SaveSlotPage("slot1.db");
     saveSlot2Page = new SaveSlotPage("slot2.db");
@@ -39,7 +39,7 @@ SaveSlotDialog::SaveSlotDialog(int &pSlotSelected, QWidget *parent) : slotSelect
     selectButton = new QPushButton;
     selectButton->setText("Select");
 
-    QObject::connect(selectButton, &QAbstractButton::clicked, this, &SaveSlotDialog::onSelectButton);
+    connect(selectButton, &QAbstractButton::clicked, this, &SaveSlotDialog::onSelectButton);
 
     horizontalLayout = new QHBoxLayout;
     horizontalLayout->addWidget(contentsWidget);


### PR DESCRIPTION
<!--https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository-->

# PR Details

It is better to use ``connect(...)`` rather than having a ``* mainWindow`` member of the class.

## Description

Remove ``*mainWindow`` and ``*mainWidget`` from classes. Add ``signals`` and connect those signals from ``MainWindow`` and ``MainWidget`` classes.

## Related Issue

None

## Motivation and Context

Do things in a more traditional Qt way.

## How Has This Been Tested

Not tested

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
